### PR TITLE
Fix for security issue spotted by George Agapov

### DIFF
--- a/crypto.h
+++ b/crypto.h
@@ -137,6 +137,7 @@ void sign(Signature *sig, const Keypair *kp, const Transaction *transaction, con
 bool verify(Signature *sig, const Compressed *pub, const Transaction *transaction, const uint8_t network_id);
 
 void compress(Compressed *compressed, const Affine *pt);
+void decompress(Affine *pt, const Compressed *compressed);
 
 void read_public_key_compressed(Compressed *out, const char *pubkeyBase58);
 void prepare_memo(uint8_t *out, const char *s);

--- a/crypto.h
+++ b/crypto.h
@@ -137,7 +137,7 @@ void sign(Signature *sig, const Keypair *kp, const Transaction *transaction, con
 bool verify(Signature *sig, const Compressed *pub, const Transaction *transaction, const uint8_t network_id);
 
 void compress(Compressed *compressed, const Affine *pt);
-void decompress(Affine *pt, const Compressed *compressed);
+bool decompress(Affine *pt, const Compressed *compressed);
 
 void read_public_key_compressed(Compressed *out, const char *pubkeyBase58);
 void prepare_memo(uint8_t *out, const char *s);

--- a/pasta_fp.c
+++ b/pasta_fp.c
@@ -17,6 +17,9 @@
 
 #include <stdint.h>
 #include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+
 typedef unsigned char fiat_pasta_fp_uint1;
 typedef signed char fiat_pasta_fp_int1;
 
@@ -24,6 +27,9 @@ typedef signed char fiat_pasta_fp_int1;
 #error "This code only works on a two's complement system"
 #endif
 
+// x^{(p - 1) / 2}
+const bool P_MINUS_1_OVER_2[] = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+const size_t P_MINUS_1_OVER_2_LEN = 254;
 
 /*
  * The function fiat_pasta_fp_addcarryx_u64 is an addition with carry.
@@ -2040,9 +2046,6 @@ void fiat_pasta_fp_divstep(uint64_t* out1, uint64_t out2[5], uint64_t out3[5], u
   out5[3] = x126;
 }
 
-#include <stdbool.h>
-#include <stddef.h>
-
 void fiat_pasta_fp_copy(uint64_t out[4], const uint64_t value[4]) {
     for (size_t j = 0; j < 4; ++j) { out[j] = value[j]; }
 }
@@ -2114,9 +2117,6 @@ bool fiat_pasta_fp_equals_one(const uint64_t x[4]) {
 }
 
 int fiat_pasta_fp_legendre(const uint64_t arg1[4]) {
-  // x^{(p - 1) / 2}
-  const bool P_MINUS_1_OVER_2[] = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-
   uint64_t tmp[4];
 
   fiat_pasta_fp_pow(tmp, arg1, P_MINUS_1_OVER_2, 254);
@@ -2149,6 +2149,12 @@ void fiat_pasta_fp_sqrt(uint64_t x[4], const uint64_t value[4]) {
 
     if (fiat_pasta_fp_equals_zero(value)) {
       for (size_t j = 0; j < 4; ++j) { x[j] = 0; }
+      return;
+    }
+
+    uint64_t check[4];
+    fiat_pasta_fp_pow(check, value, P_MINUS_1_OVER_2, P_MINUS_1_OVER_2_LEN);
+    if (!fiat_pasta_fp_equals_one(check)) {
       return;
     }
 

--- a/pasta_fp.c
+++ b/pasta_fp.c
@@ -2144,18 +2144,18 @@ void fiat_pasta_fp_print(const uint64_t x[4]) {
     printf("] \n");
 }
 
-void fiat_pasta_fp_sqrt(uint64_t x[4], const uint64_t value[4]) {
+bool fiat_pasta_fp_sqrt(uint64_t x[4], const uint64_t value[4]) {
     // A few assertions to make sure s, t, and nqr are initialized.
 
     if (fiat_pasta_fp_equals_zero(value)) {
       for (size_t j = 0; j < 4; ++j) { x[j] = 0; }
-      return;
+      return true;
     }
 
     uint64_t check[4];
     fiat_pasta_fp_pow(check, value, P_MINUS_1_OVER_2, P_MINUS_1_OVER_2_LEN);
     if (!fiat_pasta_fp_equals_one(check)) {
-      return;
+      return false;
     }
 
     uint64_t one[4];
@@ -2222,4 +2222,6 @@ void fiat_pasta_fp_sqrt(uint64_t x[4], const uint64_t value[4]) {
 
         v = m;
     }
+
+    return true;
 }

--- a/pasta_fp.h
+++ b/pasta_fp.h
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 
-void fiat_pasta_fp_sqrt(uint64_t x[4], const uint64_t value[4]);
+bool fiat_pasta_fp_sqrt(uint64_t x[4], const uint64_t value[4]);
 void fiat_pasta_fp_set_one(uint64_t out1[4]);
 void fiat_pasta_fp_add(uint64_t out1[4], const uint64_t arg1[4], const uint64_t arg2[4]);
 void fiat_pasta_fp_sub(uint64_t out1[4], const uint64_t arg1[4], const uint64_t arg2[4]);

--- a/unit_tests.c
+++ b/unit_tests.c
@@ -989,11 +989,11 @@ int main(int argc, char* argv[]) {
 
     Compressed good_pk;
     read_public_key_compressed(&good_pk, "B62qoCvDGrbMFn5bj7PRmQC7CVvXzNQSoXXo5BmwVGTZUdUV3aCgkaK");
-    decompress(&pub, &good_pk);
+    assert(decompress(&pub, &good_pk));
 
     Compressed bad_pk;
     read_public_key_compressed(&bad_pk, "B62qprBg8jPke59MztbJPLKnSY9xbEiNNG9JqSA5jKxqXHPCWMYJjPM");
-    decompress(&pub, &bad_pk);
+    assert(!decompress(&pub, &bad_pk));
   }
 
   test_scalars();

--- a/unit_tests.c
+++ b/unit_tests.c
@@ -983,6 +983,19 @@ int main(int argc, char* argv[]) {
       generate_curve_checks(true);
   }
 
+  // fiat-crypto sqrt not square
+  {
+    Affine pub;
+
+    Compressed good_pk;
+    read_public_key_compressed(&good_pk, "B62qoCvDGrbMFn5bj7PRmQC7CVvXzNQSoXXo5BmwVGTZUdUV3aCgkaK");
+    decompress(&pub, &good_pk);
+
+    Compressed bad_pk;
+    read_public_key_compressed(&bad_pk, "B62qprBg8jPke59MztbJPLKnSY9xbEiNNG9JqSA5jKxqXHPCWMYJjPM");
+    decompress(&pub, &bad_pk);
+  }
+
   test_scalars();
 
   test_fields();


### PR DESCRIPTION
`fiat_pasta_fp_sqrt`'s Tonelli--Shanks implementation doesn't terminate if `value` is not a square.

We can check for this with `value^{(p-1)/2} != 1`

